### PR TITLE
fix: make custom EditorProperty correctly use default property value

### DIFF
--- a/addons/string_wrangler/core/custom_editor_properties/editor_property_option_wrapper.gd
+++ b/addons/string_wrangler/core/custom_editor_properties/editor_property_option_wrapper.gd
@@ -26,20 +26,12 @@ func _on_option_selected(index: int) -> void:
 
 ## Description: Refreshes the editor UI when the value changes externally.
 ## Usage: Called automatically by the editor when the value is updated.
-func update_property() -> void:
-	_refresh_value()
-
-
-## Description: Synchronizes the dropdown selection with the property value.
-## Usage: Internal only — matches selected index to current property state.
-func _refresh_value() -> void:
+func _update_property() -> void:
 	var current: String = get_edited_object().get(get_edited_property())
-	var selected_idx: int = 0
 
 	for i in range(inner_control.item_count):
 		if inner_control.get_item_text(i) == current:
-			selected_idx = i
+			inner_control.select(i)
 			break
 
-	inner_control.select(selected_idx)
-	inner_control.text = inner_control.get_item_text(selected_idx)
+	inner_control.text = current


### PR DESCRIPTION
RIght now, The ↻ button to reset a property that uses your custom EditorProperty doesn't work as it should.
Because by default, the control shows the first value in the prefix array instead of the property default value.

Also, there's a typo in the method name, the missing leading underscore makes it be ignored by the engine instead of overriding the virtual method `EditorProperty._update_property`

This fixes it.